### PR TITLE
Bump the  containerd version to 1.6.12 for ubuntu

### DIFF
--- a/etc/kubez/globals.yml
+++ b/etc/kubez/globals.yml
@@ -34,7 +34,7 @@ docker_release_ubuntu: 5:20.10.7~3-0~ubuntu-xenial
 
 # runtime containerd version
 containerd_release: 1.6.4
-containerd_release_ubuntu: 1.5.5-0ubuntu3~18.04.2
+containerd_release_ubuntu: 1.6.12-0ubuntu1~18.04.1
 
 #####################
 # keepalived options


### PR DESCRIPTION
更新了etc/kubez/globals.yml中containerd_release_ubuntu的版本
Open #237 