### PR TITLE
Fix: bump global containerd version to 1.6.12 for ubuntu

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -64,7 +64,7 @@ docker_release_ubuntu: 5:20.10.7~3-0~ubuntu-xenial
 
 # runtime containerd version
 containerd_release: 1.6.4
-containerd_release_ubuntu: 1.5.5-0ubuntu3~18.04.2
+containerd_release_ubuntu: 1.6.12-0ubuntu1~18.04.1
 
 node_config_directory: "/etc/kubez/"
 


### PR DESCRIPTION
Fix part of: #237